### PR TITLE
Add job to build CIEL for Void Linux x86_64 glibc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,40 +1,40 @@
-# Build on Debian and SBCL.
-# We want to build CIEL in a sufficiently old Debian version:
-# the glibc will be compatible with lots of Debian and Ubuntu systems,
-# however building on the latest (Bullseye) would lead to incompatible glibc errors
-# when running on newer systems.
-# Buster: released in July, 2019.
-# Bullseye: released in August, 2021, supported until July, 2024.
-image: clfoundation/sbcl:2.1.5-buster
+build debian:
+  stage: build
 
-# We need to install some system dependencies,
-# to clone libraries not in Quicklisp,
-# and to update ASDF to >= 3.3.5 in order to use local-package-nicknames.
-before_script:
-  - apt-get update -qy
-  - apt-get install -y git-core tar
+  # Build on Debian and SBCL.
+  # We want to build CIEL in a sufficiently old Debian version:
+  # the glibc will be compatible with lots of Debian and Ubuntu systems,
+  # however building on the latest (Bullseye) would lead to incompatible glibc errors
+  # when running on newer systems.
+  # Buster: released in July, 2019.
+  # Bullseye: released in August, 2021, supported until July, 2024.
+  image: clfoundation/sbcl:2.1.5-buster 
 
-  # The image doesn't have Quicklisp installed by default.
-  - QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
+  # We need to install some system dependencies,
+  # to clone libraries not in Quicklisp,
+  # and to update ASDF to >= 3.3.5 in order to use local-package-nicknames.
+  before_script:
+    - apt-get update -qy
+    - apt-get install -y git-core tar
 
-  # Upgrade ASDF (UIOP) to 3.3.5 because we want package-local-nicknames.
-  - mkdir -p ~/common-lisp/asdf/
-  - ( cd ~/common-lisp/ && wget https://asdf.common-lisp.dev/archives/asdf-3.3.5.tar.gz  && tar -xvf asdf-3.3.5.tar.gz && mv asdf-3.3.5 asdf )
-  - echo "Content of ~/common-lisp/asdf/:" && ls ~/common-lisp/asdf/
+    # The image doesn't have Quicklisp installed by default.
+    - QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
 
-  # Install system dependencies
-  - make debian-deps
-  # Clone upstream QL libraries.
-  - make ql-deps
+    # Upgrade ASDF (UIOP) to 3.3.5 because we want package-local-nicknames.
+    - mkdir -p ~/common-lisp/asdf/
+    - ( cd ~/common-lisp/ && wget https://asdf.common-lisp.dev/archives/asdf-3.3.5.tar.gz  && tar -xvf asdf-3.3.5.tar.gz && mv asdf-3.3.5 asdf )
+    - echo "Content of ~/common-lisp/asdf/:" && ls ~/common-lisp/asdf/
 
-build:
-  # stage: build
+    # Install system dependencies
+    - make debian-deps
+    # Clone upstream QL libraries.
+    - make ql-deps
   script:
     - make build
     # - make image
-    - mv bin ciel-v0
+    - mv bin ciel-v0-debian
 
   artifacts:
-    name: "ciel-v0"
+    name: "ciel-v0-debian"
     paths:
-      - ciel-v0/
+      - ciel-v0-debian/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,11 @@
-image: clfoundation/sbcl
+# Build on Debian and SBCL.
+# We want to build CIEL in a sufficiently old Debian version:
+# the glibc will be compatible with lots of Debian and Ubuntu systems,
+# however building on the latest (Bullseye) would lead to incompatible glibc errors
+# when running on newer systems.
+# Buster: released in July, 2019.
+# Bullseye: released in August, 2021, supported until July, 2024.
+image: clfoundation/sbcl:2.1.5-buster
 
 # We need to install some system dependencies,
 # to clone libraries not in Quicklisp,

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,3 +38,31 @@ build debian:
     name: "ciel-v0-debian"
     paths:
       - ciel-v0-debian/
+
+build void:
+  stage: build
+  # Use custom docker image since the official ones
+  # can't be used in gitlab CI pipelines
+  image: cinerion/ciel-sbcl-voidlinux
+
+  # We need to install some system dependencies,
+  # to clone libraries not in Quicklisp,
+  # and to update ASDF to >= 3.3.5 in order to use local-package-nicknames.
+  before_script:
+    - xbps-install -Syu
+
+    # Upgrade ASDF (UIOP) to 3.3.5 because we want package-local-nicknames.
+    - mkdir -p ~/common-lisp/asdf/
+    - ( cd ~/common-lisp/ && wget https://asdf.common-lisp.dev/archives/asdf-3.3.5.tar.gz  && tar -xvf asdf-3.3.5.tar.gz && mv asdf-3.3.5 asdf )
+    - echo "Content of ~/common-lisp/asdf/:" && ls ~/common-lisp/asdf/
+
+    # Clone upstream QL libraries.
+    - make ql-deps
+  script:
+    - make build
+    - mv bin ciel-v0-void
+
+  artifacts:
+    name: "ciel-v0-void"
+    paths:
+      - ciel-v0-void/

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ REPL. You need to build the core image yourself though.
   <https://gitlab.com/vindarel/ciel/-/pipelines>, download the latest
   artifacts, unzip the `ciel-v0.zip` archive and run `ciel-v0/ciel`.
 
+It is currently built on Debian Buster (released in 2019) and it
+should be compatible with newer Debian-ish systems.
+
 TODO: build it for different platforms.
 
 To build it, clone this repository and run `make build`.

--- a/src/scripts/finder.lisp
+++ b/src/scripts/finder.lisp
@@ -15,7 +15,10 @@
 (defun find-on-directory (root params)
   (fof:finder*
    :root root
-   :predicates (apply #'fof/p:every-path~ params)))
+   ;; "and" the params: needs ongoing PR.
+   ;; :predicates (apply #'fof/p:every-path~ params)))
+   ;; does a "or":
+   :predicates (apply #'fof/p:path~ params)))
 
 (defun find-files (&optional params)
   (unless params


### PR DESCRIPTION
This PR builds on top of the commits that were present on the Gitlab fork.

The changes made are:

- Refactor the former gitlab-ci.yml so that it becomes a single build job for Debian
- Add a job to build CIEL for Void Linux
- The artifacts' names now have the name of the distro they are built for

I tried building the CIEL binary for Void using the official Void Linux Docker images,
but i encountered a very bizarre bug in which the default `sh` binary would crash,
so i decided to make a Dockerfile and image to solve this and include all system
dependencies required by CIEL in passing.

Docker file: https://github.com/cinerion/sbcl-voidlinux-docker