### PR TITLE
Install quicklisp on CI for void linux binaries.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,9 @@ build void:
   before_script:
     - xbps-install -Syu
 
+    # The image doesn't have Quicklisp installed by default.
+    - QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp
+
     # Upgrade ASDF (UIOP) to 3.3.5 because we want package-local-nicknames.
     - mkdir -p ~/common-lisp/asdf/
     - ( cd ~/common-lisp/ && wget https://asdf.common-lisp.dev/archives/asdf-3.3.5.tar.gz  && tar -xvf asdf-3.3.5.tar.gz && mv asdf-3.3.5 asdf )


### PR DESCRIPTION
Since quicklisp has been updated there is no longer a need to manually install dependencies.

Also, I have moved the quicklisp installation step from the docker image creation (which is now done monthly through github actions so it doesn't get too stale in the future) to the void linux build job on gitlab CI in this repo. 

I could have updated the quicklisp dist, but to keep debian's and void's build jobs somewhat uniform I think it might be better to just install quicklisp through this repo's CI.