### PR TITLE
Fix system update order for void linux job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,8 +49,9 @@ build void:
   # to clone libraries not in Quicklisp,
   # and to update ASDF to >= 3.3.5 in order to use local-package-nicknames.
   before_script:
+    - xbps-install -S
     - xbps-install -uy xbps
-    - xbps-install -Syu
+    - xbps-install -uy
 
     # The image doesn't have Quicklisp installed by default.
     - QUICKLISP_ADD_TO_INIT_FILE=true /usr/local/bin/install-quicklisp


### PR DESCRIPTION
Due to the current order of operations the void linux build of the CIEL binary has been failing for about 2 months now. I realized a few hours ago.

With this PR the new order for updating the system in the CI is:
1. Pull updates list from void repos
2. Update xbps in case it's outdated
3. Update all other packages

Also, the docker images were a bit outdated, 4 months iirc, because the github actions on my repo broke at that time, so i fixed that and the void images with SBCL are up to date again.

Cheers