### PR TITLE
Allow use of a custom quicklisp directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 LISP ?= sbcl
+QUICKLISP_DIR ?= ~/quicklisp
 
 all: build
 
@@ -9,31 +10,31 @@ ql-deps:
 	# and cl-form-types.
 	# See issue https://github.com/ciel-lang/CIEL/issues/38
 	# This has been fixed upstream, not yet in Quicklisp
-	git clone https://github.com/alex-gutev/cl-environments ~/quicklisp/local-projects/cl-environments
-	git clone https://github.com/alex-gutev/cl-form-types ~/quicklisp/local-projects/cl-form-types
+	git clone https://github.com/alex-gutev/cl-environments $(QUICKLISP_DIR)/local-projects/cl-environments
+	git clone https://github.com/alex-gutev/cl-form-types $(QUICKLISP_DIR)/local-projects/cl-form-types
 
 	# 2024-08: Moira needs moira/light, added <2023-11-23 Thu>, not on Quicklisp…
 	# moira/light doesn't depend on Osicat.
-	git clone https://github.com/ruricolist/moira/ ~/quicklisp/local-projects/moira
+	git clone https://github.com/ruricolist/moira/ $(QUICKLISP_DIR)/local-projects/moira
 
 	# 2024-08: simple progress bar, not in Quicklisp.
-	git clone https://github.com/vindarel/progressons ~/quicklisp/local-projects/progressons
+	git clone https://github.com/vindarel/progressons $(QUICKLISP_DIR)/local-projects/progressons
 
 	# termp, little utility
-	git clone https://github.com/vindarel/termp ~/quicklisp/local-projects/termp
+	git clone https://github.com/vindarel/termp $(QUICKLISP_DIR)/local-projects/termp
 
 	# 2024-08: not in Quicklisp
-	git clone https://github.com/lisp-maintainers/file-finder ~/quicklisp/local-projects/file-finder
+	git clone https://github.com/lisp-maintainers/file-finder $(QUICKLISP_DIR)/local-projects/file-finder
 
 	# <2024-08-30> error with SBCL: Lock on package SB-DI violated…
 	# fixed https://github.com/Shinmera/dissect/issues/18 on March, 2024 (not in Quicklisp…)
-	git clone https://github.com/Shinmera/dissect/ ~/quicklisp/local-projects/dissect
+	git clone https://github.com/Shinmera/dissect/ $(QUICKLISP_DIR)/local-projects/dissect
 
 	# fix fset on latest SBCL
 	# "Lock on package SB-EXT violated when interning ONCE-ONLY while in package FSET"
 	# see https://github.com/slburson/fset/pull/46
-	git clone https://gitlab.common-lisp.net/misc-extensions/misc-extensions ~/quicklisp/local-projects/misc-extensions
-	git clone https://github.com/slburson/fset/ ~/quicklisp/local-projects/fset
+	git clone https://gitlab.common-lisp.net/misc-extensions/misc-extensions $(QUICKLISP_DIR)/local-projects/misc-extensions
+	git clone https://github.com/slburson/fset/ $(QUICKLISP_DIR)/local-projects/fset
 
 # Install some system dependencies.
 debian-deps:


### PR DESCRIPTION
This way people who don't have their quicklisp installed under $HOME/quicklisp (I don't) can get the repos installed in the correct directory.