### PR TITLE
Add documentation for Guix

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,12 +1,16 @@
 
 # Install
 
-## Download a binary. For scripting and the custom REPL.
+CIEL can be used in two different roles:
 
-Getting a binary allows you to run scripts, to play around in its
-terminal readline REPL. A binary doesn't allow you to use CIEL in your
-existing Common Lisp editor (which still offers the most interactive
-and fast development experience).
+- As a library that you can load into any Common Lisp implementation.
+- As a binary based on `sbcl`, which  is a command-line tool for use in the terminal or in shell scripts. It provides a more feature-rich REPL than standard `sbcl`, and a much faster startup time than starting `sbcl` and then loading the CIEL library.
+
+If you use a Lisp development environment, such as Emacs with Slime, you should opt for the library rather than the binary. To get the same fast startup time, you can use a prebuilt core image, as we will explain below.
+
+In the following, we will explain how to install the library, the binary, and the prebuilt core image, for various common SBCL setups.
+
+## Download a prebuilt binary.
 
 To download a CIEL binary:
 
@@ -14,7 +18,7 @@ To download a CIEL binary:
 - we provide a binary from a CI for some systems: go to
   <https://gitlab.com/vindarel/ciel/-/pipelines>, download the latest
   artifacts, unzip the `ciel-v0-{platform}.zip` archive and run `ciel-v0-{platform}/ciel`.
-- using the [Guix](https://guix.gnu.org/) package manager, install package `sbcl-ciel-repl`.
+- if you use the [Guix](https://guix.gnu.org/) package manager, install package `sbcl-ciel-repl`.
 
 CIEL is currently built for the following platforms:
 
@@ -23,18 +27,135 @@ CIEL is currently built for the following platforms:
 | debian   | Debian Buster (2019)          |
 | void     | Void Linux glibc (2023-05), using [cinerion's Docker image](https://github.com/cinerion/sbcl-voidlinux-docker)  |
 
-
-Start it with `./ciel`.
+Start it with `./ciel` (adapt the path if you put the binary somewhere else).
 
 With no arguments, you enter CIEL's terminal REPL.
 
 You can give a CIEL script as first argument, or call a built-in one. See the scripting section.
 
-# Build
+## Run the binary in a Docker container
+
+We have a Dockerfile.
+
+Build your CIEL image:
+
+    docker build -t ciel .
+
+The executable is built in `/usr/local/bin/ciel` of the Docker image.
+
+Get a CIEL REPL:
+
+    docker run --rm -it ciel /usr/local/bin/ciel
+
+Run a script on your filesystem:
+
+    docker run --rm -it ciel /usr/local/bin/ciel path/to/your/lisp/script.lisp
+
+Run a built-in script:
+
+    docker run --rm -it ciel /usr/local/bin/ciel -s simpleHTTPserver
+
+So, save you some typing with a shell alias:
+
+    alias ciel="sudo docker run --rm -it ciel /usr/local/bin/ciel"
+
+## Install CIEL as a library
+
+You can install and CIEL like any other Common Lisp library, but you must make sure to also get all of its dependencies, a task that is best left to a package manager.
+
+### Quicklisp
+
+CIEL is not on Quicklisp yet, but it is on [Ultralisp](https://ultralisp.org).
+
+So, either clone this repository:
+
+    git clone https://github.com/ciel-lang/CIEL ~/quicklisp/local-projects/CIEL
+
+or install the Ultralisp distribution and pull the library from there:
+
+```lisp
+(ql-dist:install-dist "http://dist.ultralisp.org/" :prompt nil)
+```
+
+#### Install our Lisp dependencies [MANDATORY]
+
+Even if you have a Lisp setup with Quicklisp installed, the current
+distribution of Quicklisp is quite old (as of August, 2024) and you
+need to pull recent dependencies.
+
+We'll clone the required ones into your `~/quicklisp/local-projects/`.
+
+    make ql-deps
+
+Other tools exist for this (Qlot, ocicl…), we are just not using them yet.
+
+#### Loading CIEL with Quicklisp
+
+Now, in both cases, you can load the `ciel.asd` file (with `asdf:load-asd`
+or `C-c C-k` in Slime) or quickload "ciel":
+
+```lisp
+(ql:quickload "ciel")
+```
+
+be sure to enter the `ciel-user` package:
+
+```lisp
+(in-package :ciel-user)
+```
+you now have access to all CIEL's packages and functions.
+
+### Guix
+
+CIEL is available via the [Guix](https://guix.gnu.org/) package manager, as a source code package (`cl-ciel`) or precompiled for SBCL (`sbcl-ciel`) and ECL (`ecl-ciel`). You have to add Lisp itself (package `sbcl` or `ecl`), and any other Lisp library you may want to use.
+
+In Lisp, do
+```lisp
+(require "asdf")
+(asdf:load-system :ciel)
+(in-package :ciel-user)
+```
+
+Alternatively, or in addition, you can install `sbcl-ciel:image`, which contains a prebuilt core image under `bin/ciel.image`. It is executable, so you can run it in place of `sbcl`, or you can load it from the `sbcl` command line:
+
+```
+sbcl --core $(GUIX_PROFILE)/bin/ciel.image
+```
+
+In either case, you get a Lisp environment with CIEL preloaded, so all you have to do is
+
+```lisp
+(in-package :ciel-user)
+```
+
+
+## Using CIEL as a library in your Lisp code
+
+To use it in your project, create a package and "use" `ciel` in addition
+to `cl`:
+
+```lisp
+(defpackage yourpackage
+  (:use :cl :ciel))
+```
+
+Alternatively, you can use `generic-ciel`, based on
+[generic-cl](https://github.com/alex-gutev/generic-cl/) (warn:
+generic-ciel is less tested at the moment).
+
+```lisp
+(defpackage yourpackage
+  (:use :cl :generic-ciel))
+```
+
+`generic-cl` allows you to define `+` or `equalp` methods for your own
+objects (and more).
+
+# Building CIEL binaries and core images
 
 To build CIEL, both the binary and the core image, you need a couple
 system dependencies and you have to check a couple things on the side
-of lisp before proceeding.
+of Lisp before proceeding.
 
 ## Dependencies
 
@@ -103,57 +224,11 @@ sbcl --load ~/quicklisp/setup.lisp --eval "(ql:add-to-init-file)" --quit
 
 It creates a `~/quicklisp/` directory. Read its installation instructions to know more.
 
-### Install our Lisp dependencies [MANDATORY]
+See the section above for loading CIEL via Quicklisp for how to make sure you have all the required dependencies.
 
-Even if you have a Lisp setup with Quicklisp installed, the current
-distribution of Quicklisp is quite old (as of August, 2024) and you
-need to pull recent dependencies.
-
-We'll clone the required ones into your `~/quicklisp/local-projects/`.
-
-    make ql-deps
-
-Other tools exist for this (Qlot, ocicl…), we are just not using them yet.
-
-
-## How to load CIEL with Quicklisp
+### Run the build procedure
 
 You need the dependencies above: Quicklisp, a good ASDF version, our up-to-date Lisp dependencies.
-
-This shows you how to load CIEL and all its goodies, in order to use it in your current editor.
-
-CIEL is not on Quicklisp yet, but it is on [Ultralisp](https://ultralisp.org).
-
-So, either clone this repository:
-
-    git clone https://github.com/ciel-lang/CIEL ~/quicklisp/local-projects/CIEL
-
-or install the Ultralisp distribution and pull the library from there:
-
-```lisp
-(ql-dist:install-dist "http://dist.ultralisp.org/" :prompt nil)
-```
-
-Now, in both cases, you can load the `ciel.asd` file (with `asdf:load-asd`
-or `C-c C-k` in Slime) and quickload "ciel":
-
-```lisp
-(ql:quickload "ciel")
-```
-
-be sure to enter the `ciel-user` package:
-
-```lisp
-(in-package :ciel-user)
-```
-you now have access to all CIEL's packages and functions.
-
-
-## How to build a CIEL binary and a core image
-
-If you use the [Guix](https://guix.gnu.org/) package manager, install package output `sbcl-ciel:image`. It contains a prebuilt image under `bin/ciel.image`.
-
-For all other setups, you have to build a core image yourself. You need the dependencies above: Quicklisp, a good ASDF version, our up-to-date Lisp dependencies.
 
 To build CIEL's binary, use:
 
@@ -169,7 +244,9 @@ To create a Lisp image:
 
 This creates the `ciel-core` Lisp image.
 
-Unlike a binary, we can not distribute core images. It is dependent on the machine it was built on.
+Unlike binaries, we cannot distribute core images. They depend on the machine they was were built on.
+
+### Using the core image
 
 The way we use a core image is to load it at startup like this:
 
@@ -180,60 +257,7 @@ It loads fast and you have all CIEL libraries and goodies at your disposal.
 Then you have to configure your editor, like Slime, to have the choice of the Lisp image to
 start. See below.
 
-
-## Docker
-
-We have a Dockerfile.
-
-Build your CIEL image:
-
-    docker build -t ciel .
-
-The executable is built in `/usr/local/bin/ciel` of the Docker image.
-
-Get a CIEL REPL:
-
-    docker run --rm -it ciel /usr/local/bin/ciel
-
-Run a script on your filesystem:
-
-    docker run --rm -it ciel /usr/local/bin/ciel path/to/your/lisp/script.lisp
-
-Run a built-in script:
-
-    docker run --rm -it ciel /usr/local/bin/ciel -s simpleHTTPserver
-
-So, save you some typing with a shell alias:
-
-    alias ciel="sudo docker run --rm -it ciel /usr/local/bin/ciel"
-
-# Usage as a library
-
-## "use" ciel in your Lisp systems
-
-You can install and `quickload` CIEL like any other Common Lisp library. It is also available via the [Guix](https://guix.gnu.org/) package manager, as a source code package (`cl-ciel`) or precompiled for SBCL (`sbcl-ciel`) and ECL (`ecl-ciel`).
-
-To use it in your project, create a package and "use" `ciel` in addition
-of `cl`:
-
-```lisp
-(defpackage yourpackage
-  (:use :cl :ciel))
-```
-
-You can also use `generic-ciel`, based on
-[generic-cl](https://github.com/alex-gutev/generic-cl/) (warn:
-generic-ciel is less tested at the moment).
-
-~~~lisp
-    (defpackage yourpackage
-      (:use :cl :generic-ciel))
-~~~
-
-generic-cl allows us to define our `+` or `equalp` methods for our own
-objects (and more).
-
-## Core image: configure your editor
+### Core image: configure your editor
 
 The advantage of a core image is that it loads instantly, faster than
 a `(ql:quickload "ciel")`. We'll ask our editor to start SBCL with our

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,6 +14,7 @@ To download a CIEL binary:
 - we provide a binary from a CI for some systems: go to
   <https://gitlab.com/vindarel/ciel/-/pipelines>, download the latest
   artifacts, unzip the `ciel-v0-{platform}.zip` archive and run `ciel-v0-{platform}/ciel`.
+- using the [Guix](https://guix.gnu.org/) package manager, install package `sbcl-ciel-repl`.
 
 CIEL is currently built for the following platforms:
 
@@ -150,7 +151,9 @@ you now have access to all CIEL's packages and functions.
 
 ## How to build a CIEL binary and a core image
 
-You need the dependencies above: Quicklisp, a good ASDF version, our up-to-date Lisp dependencies.
+If you use the [Guix](https://guix.gnu.org/) package manager, install package output `sbcl-ciel:image`. It contains a prebuilt image under `bin/ciel.image`.
+
+For all other setups, you have to build a core image yourself. You need the dependencies above: Quicklisp, a good ASDF version, our up-to-date Lisp dependencies.
 
 To build CIEL's binary, use:
 
@@ -208,7 +211,7 @@ So, save you some typing with a shell alias:
 
 ## "use" ciel in your Lisp systems
 
-You can install and `quickload` CIEL like any other Common Lisp library.
+You can install and `quickload` CIEL like any other Common Lisp library. It is also available via the [Guix](https://guix.gnu.org/) package manager, as a source code package (`cl-ciel`) or precompiled for SBCL (`sbcl-ciel`) and ECL (`ecl-ciel`).
 
 To use it in your project, create a package and "use" `ciel` in addition
 of `cl`:


### PR DESCRIPTION
This is a minimal patch to document usage of CIEL with Guix. It would be better to restructure the installation instructions, to guide users immediately to the sections that are relevant for them. I'll look into that later.